### PR TITLE
Save as Draft dialog prevent mapping creation. 

### DIFF
--- a/onContentEdit.cfm
+++ b/onContentEdit.cfm
@@ -46,8 +46,6 @@ function loadLocaleTable(activeTab){
 	var pars = 'contentID=#request.contentBean.getContentID()#&contentHistID=#request.contentBean.getContentHistID()#&type=#attributes.type#&parentID=#attributes.parentID#&siteid=#attributes.siteID#&doMap=#yesNoFormat(event.valueExists("doMap"))#&cacheid=' + Math.random();
 	var tab = activeTab;	
 	
-	jQuery("##localeTableContainer").html('<br/><img src="images/progress_bar.gif">');
-	
 	//location.href=url + "?" + pars;
 	jQuery(".initActiveTab").each(
 		function(index) {			


### PR DESCRIPTION
Problem: When editing content and attempting to assign/create a translation mapping the user can't get past the "Save as Draft" dialog.  The dialog functions properly, but the user is never redirected to the plugin for the purpose of creating a translation mapping. Instead the edit screen they were on merely refreshes, taking them essentially no where. 

This change allows the user to actually enter the plugin after making their choice in the "Save as draft" dialog.
